### PR TITLE
fix(expath-pkg.xml): do not build broken expath-pkg.xml files

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -23,10 +23,18 @@
       <fileset file="expath-pkg.xml" />
       <filterchain>
         <replacetokens>
-          <token key="version" value="${app.version}" />
           <token key="commit-id" value="${git.revision}" />
           <token key="commit-time" value="${git.time}" />
         </replacetokens>
+
+		<!--
+			Replace the 'version="1.0"' string in the expath-pkg.xml with the correct version. Do
+			not use normal token replacement for this since the regular token approach (%version%)
+			is forbidden in expath-pkg.xml. Instead, replace version=".*", but not in the XML header
+		-->
+		<replaceregex
+			pattern="(?&lt;!xml )version=&quot;.*&quot;"
+			replace="version=&quot;${app.version}&quot;" />
       </filterchain>
     </copy>
   </target>

--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://expath.org/ns/pkg" name="https://betamasaheft.eu/betmasdata/corpora"
-  abbrev="corpora" version="@version@" spec="1.0">
+  abbrev="corpora" version="1.0.0" spec="1.0">
     <title>Beta Masaheft Data - corpora</title>
     <dependency processor="http://exist-db.org" semver-min="5.2.0"/>
 </package>


### PR DESCRIPTION
The @version@ is forbidden for expath packages. This way we always have a valid version in our hands